### PR TITLE
Use friendly labels for partner and conversion ID

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -40,7 +40,7 @@ ___TEMPLATE_PARAMETERS___
         "type": "POSITIVE_NUMBER"
       }
     ],
-    "displayName": "partnerId",
+    "displayName": "Partner ID",
     "simpleValueType": true,
     "name": "partnerId",
     "type": "TEXT",
@@ -57,7 +57,7 @@ ___TEMPLATE_PARAMETERS___
         "type": "POSITIVE_NUMBER"
       }
     ],
-    "displayName": "conversionId",
+    "displayName": "Conversion ID",
     "simpleValueType": true,
     "name": "conversionId",
     "type": "TEXT",


### PR DESCRIPTION
Just a minor thing. Might as well use friendly labels when being displayed in the GTM UI.